### PR TITLE
(feat): Add disaster simulation events + proxy improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ vault/logs
 terraform/.terraform/*
 
 # .tfstate files
+terraform.plan
 *.tfstate
 *.tfstate.*
 .terraform.lock.hcl

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ MAKEFLAGS += --silent
 
 vault-up:
 	docker compose up --remove-orphans -d --build
-vault-enable-ha:
+vault-scale-up:
 	docker compose up --scale vault=5 -d --no-recreate
 terraform-init:
 	docker compose exec vault-operator terraform init
@@ -16,7 +16,15 @@ vault-operator-creds:
 	docker compose exec vault-operator credentials.sh
 vault-down:
 	docker compose down -v
+vault-stop-leader:
+	set -euo pipefail; \
+	container_id=`docker compose exec vault-operator get-node.sh leader`; \
+	docker stop $$container_id
+vault-stop-follower:
+	set -euo pipefail; \
+	container_id=`docker compose exec vault-operator get-node.sh follower`; \
+	docker stop $$container_id
 url := http://localhost:8080
 vault-ui:
 	(open "$(url)" || xdg-open "$(url)") &> /dev/null || \
-		echo "Vist $(url) in browser"
+		6vecho "Vist $(url) in browser"

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ to ensure that dead servers are cleaned up appropriately
 make vault-up
 
 # Enable High Availability by Scaling Up Vault Cluster to 5 Nodes
-make vault-enable-ha
+make vault-scale-up
 
 # Apply Raft Autopilot Configuration Through Terraform
 make terraform-init
@@ -66,3 +66,19 @@ make terraform-plan
 # Run `terraform apply -auto-approve terraform.plan`
 make terraform-apply
 ```
+
+# Disaster Simulation
+
+The following commands can be executed to simulate disaster events like a Node being terminated or losing communication with the Vault cluster.
+Once high-availability is enabled, you can opt to either terminate a follower or leader node. The latter option allowing us to witness the leader re-election process.
+```
+# Stop a Follower Node
+make vault-stop-follower
+
+# Stop a Leader Node
+make vault-stop-leader
+
+# Restore Vault Cluster to Healthy State (5 Nodes)
+make vault-scale-up
+```
+

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -48,14 +48,8 @@ services:
       context: nginx
     ports:
       - "8080:8080"
-    healthcheck:
-      test: curl -sSf http://localhost:8080/v1/sys/health
-      interval: "5s"
 
   vault-operator:
-    depends_on:
-      vault-proxy:
-        condition: service_healthy
     build: 
       context: operator
     volumes:

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -4,15 +4,14 @@ events {
     worker_connections 1000;
 }
 
-http {
-    upstream all {
-        server vault:8200;
-    }
-       
+http {       
     server {
         listen 8080;
+        resolver 127.0.0.11 valid=10s;
+
         location / {
-            proxy_pass http://all/;
+            set $backend vault:8200;
+            proxy_pass http://$backend$request_uri;
         }
     }
 }

--- a/operator/.profile
+++ b/operator/.profile
@@ -1,12 +1,8 @@
 #!/bin/sh
 
 # Get Vault Operator Vault Token
-VAULT_TOKEN="$(vault login \
+export VAULT_TOKEN="$(vault login \
     --method=userpass \
     "username=${TERRAFORM_VAULT_USERNAME}" \
     "password=${TERRAFORM_VAULT_PASSWORD}" \
     -format=json | jq -r '.auth.client_token')"
-
-echo "Vault Address:    ${VAULT_ADDR}"
-echo "Vault Token:      ${VAULT_TOKEN:0:7}***"
-

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -7,6 +7,7 @@ COPY --from=hashicorp/terraform:latest /bin/terraform /bin/terraform
 
 COPY .profile /root/.profile
 COPY credentials.sh /usr/local/bin/credentials.sh
+COPY get-node.sh /usr/local/bin/get-node.sh
 COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 
 WORKDIR "/terraform"

--- a/operator/docker-entrypoint.sh
+++ b/operator/docker-entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-function clean_up() {
+clean_up() {
     # Clean Up Terraform State Files
     find /terraform -regex "/terraform/\.*terraform.*" | xargs rm -rf
 }

--- a/operator/get-node.sh
+++ b/operator/get-node.sh
@@ -1,0 +1,29 @@
+#!/bin/sh -l
+set -euo pipefail
+
+node_type="${1:-}"
+
+if [ "${node_type}" != "leader" ] && [ "${node_type}" != "follower" ]; then
+    cat << EOF >&2
+ERROR: Must provide a valid argument to get-node.sh
+Current Value:  ${1:-}
+Expected Values: [leader, follower]
+EOF
+    exit 1
+fi
+
+set +e
+if [ "${node_type}" = "leader" ]; then
+    container_id="$(vault operator raft list-peers -format=json | jq -er '.data.config.servers | map(select(.leader)) | first | .node_id')"
+else
+    container_id="$(vault operator raft list-peers -format=json | jq -er '.data.config.servers | map(select(.leader|not)) | first | .node_id')"
+fi
+status="$?"
+set -e
+
+if [ "${status}" != "0" ]; then
+    echo "ERROR: Could not identify a node of type ${node_type}" >&2
+    exit 1
+else
+    echo "${container_id}"
+fi


### PR DESCRIPTION
Add `make` commands `vault-stop-leader` and `vault-stop-follower` to allow developers to simulate node failure. Also improved the NGINX proxy to resolve the IP addresses behind the `vault` service every 10 seconds. This is essential as the `vault` service can represent a dynamic number of containers.