### PR TITLE
(hotfix): Fix dockerfile issue for vault

### DIFF
--- a/vault/Dockerfile
+++ b/vault/Dockerfile
@@ -1,6 +1,6 @@
 FROM hashicorp/vault:latest as base
 
-RUN apk update & apk add gettext curl jq
+RUN apk update && apk add gettext curl jq
 COPY initialise.sh /usr/local/bin/initialise.sh
 COPY docker-entrypoint.sh /usr/local/bin/.docker-entrypoint.sh
 ENTRYPOINT [".docker-entrypoint.sh"]


### PR DESCRIPTION
Missing double `&&` in `Dockerfile`