### PR TITLE
Change Dead Server Last Contact to 1m

### DIFF
--- a/terraform/raft_autopilot.tf
+++ b/terraform/raft_autopilot.tf
@@ -1,6 +1,6 @@
 resource "vault_raft_autopilot" "autopilot" {
   cleanup_dead_servers = true
-  dead_server_last_contact_threshold = "30s"
+  dead_server_last_contact_threshold = "1m"
   last_contact_threshold = "15s"
   max_trailing_logs = 1000
   min_quorum = 3


### PR DESCRIPTION
It seems that Vault no longer recognises `30s` as a valid value for `dead_server_last_contact_threshold`. Setting it to `1m`, the lowest supported value