### PR TITLE
(hotfix): Improved Linux compatibility and documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
-MAKEFLAGS += --silent
+SHELL := /usr/bin/env bash
+.SHELLFLAGS := -euo pipefail -c
 
 vault-up:
 	docker compose up --remove-orphans -d --build
@@ -17,14 +18,12 @@ vault-operator-creds:
 vault-down:
 	docker compose down -v
 vault-stop-leader:
-	set -euo pipefail; \
 	container_id=`docker compose exec vault-operator get-node.sh leader`; \
 	docker stop $$container_id
 vault-stop-follower:
-	set -euo pipefail; \
 	container_id=`docker compose exec vault-operator get-node.sh follower`; \
 	docker stop $$container_id
-url := http://localhost:8080
+URL := http://localhost:8080
 vault-ui:
-	(open "$(url)" || xdg-open "$(url)") &> /dev/null || \
-		6vecho "Vist $(url) in browser"
+	(open "$(URL)" || xdg-open "$(URL)") &> /dev/null || \
+		echo "Vist $(URL) in browser"

--- a/README.md
+++ b/README.md
@@ -2,12 +2,24 @@
 
 ## Prerequisites
 
+This sandbox environment is provisioned and managed through an assortment of `docker` commands 
+which means that it can be provisioned by **any** Operating System that supports the `docker` runtime engine: Windows, MacOS, Linux.
+
+> **Note**: Configuring `bash` and `make` on Windows is not as trivial as MacOS and Linux. If you want
+to avoid this hassle, then simply manually execute the corresponding commands from the `Makefile`
+
 ### make
 
 ```
-# Linux
+# Ubuntu
 sudo apt-get update
-sudo apt-get install build-essential
+sudo apt-get install make
+
+# CentOS/Fedora/RHEL
+sudo dnf install make
+
+# Arch Linux
+sudo pacman -S make
 
 # MacOS
 sudo xcode-select --install


### PR DESCRIPTION
Adding compatibility for Linux, explicitly setting `bash` as the Shell for `Makefile` commands, and adding instructions on how to install `make` for other popular Linux distributions. Mentioned that Windows is supported,  but you will just have to manually execute the commands from the `Makefile`